### PR TITLE
Make exported API more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ Set `GOMAXPROCS` to match container CPU quota.
 
 `go get -u go.uber.org/automaxprocs`
 
+## Quick Start
+
+```go
+import (
+  "log"
+
+  "go.uber.org/automaxprocs"
+)
+
+func main() {
+  undo, err := automaxprocs.Set()
+  defer undo()
+  if err != nil {
+    log.Fatalf("failed to set GOMAXPROCS: %v", err)
+  }
+  // Insert your application logic here.
+}
+```
+
 ## Development Status: Stable
 
 All APIs are finalized, and no breaking changes will be made in the 1.x series

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # automaxprocs [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-Set `GOMAXPROCS` to match container CPU quota.
+Automatically set `GOMAXPROCS` to match Linux container CPU quota.
 
 ## Installation
 
@@ -9,19 +9,10 @@ Set `GOMAXPROCS` to match container CPU quota.
 ## Quick Start
 
 ```go
-import (
-  "log"
-
-  "go.uber.org/automaxprocs"
-)
+import _ "go.uber.org/automaxprocs"
 
 func main() {
-  undo, err := automaxprocs.Set()
-  defer undo()
-  if err != nil {
-    log.Fatalf("failed to set GOMAXPROCS: %v", err)
-  }
-  // Insert your application logic here.
+  // Your application logic here.
 }
 ```
 

--- a/automaxprocs_test.go
+++ b/automaxprocs_test.go
@@ -49,7 +49,7 @@ func withMax(t testing.TB, n int, f func()) {
 func testLogger() (*bytes.Buffer, Option) {
 	buf := bytes.NewBuffer(nil)
 	printf := func(template string, args ...interface{}) {
-		buf.WriteString(fmt.Sprintf(template, args...))
+		fmt.Fprintf(buf, template, args...)
 	}
 	return buf, Logger(printf)
 }

--- a/automaxprocs_test.go
+++ b/automaxprocs_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package automaxprocs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	iruntime "go.uber.org/automaxprocs/internal/runtime"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withMax(t testing.TB, n int, f func()) {
+	prevStr, ok := os.LookupEnv(_maxProcsKey)
+	want := strconv.FormatInt(int64(n), 10)
+	require.NoError(t, os.Setenv(_maxProcsKey, want), "couldn't set GOMAXPROCS")
+	f()
+	if ok {
+		require.NoError(t, os.Setenv(_maxProcsKey, prevStr), "couldn't restore original GOMAXPROCS value")
+		return
+	}
+	require.NoError(t, os.Unsetenv(_maxProcsKey), "couldn't clear GOMAXPROCS")
+}
+
+func testLogger() (*bytes.Buffer, Option) {
+	buf := bytes.NewBuffer(nil)
+	printf := func(template string, args ...interface{}) {
+		buf.WriteString(fmt.Sprintf(template, args...))
+	}
+	return buf, Logger(printf)
+}
+
+func stubProcs(f func(int) (int, iruntime.CPUQuotaStatus, error)) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.procs = f
+	})
+}
+
+func TestLogger(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		// Calling Set without options should be safe.
+		undo, err := Set()
+		defer undo()
+		require.NoError(t, err, "Set failed")
+	})
+
+	t.Run("override", func(t *testing.T) {
+		buf, opt := testLogger()
+		undo, err := Set(opt)
+		defer undo()
+		require.NoError(t, err, "Set failed")
+		assert.True(t, buf.Len() > 0, "didn't capture log output")
+	})
+}
+
+func TestSet(t *testing.T) {
+	// Ensure that we've undone any modifications correctly.
+	prev := currentMaxProcs()
+	defer func() {
+		require.Equal(t, prev, currentMaxProcs(), "didn't undo GOMAXPROCS changes")
+	}()
+
+	t.Run("EnvVarPresent", func(t *testing.T) {
+		withMax(t, 42, func() {
+			prev := currentMaxProcs()
+			undo, err := Set()
+			defer undo()
+			require.NoError(t, err, "Set failed")
+			assert.Equal(t, prev, currentMaxProcs(), "shouldn't alter GOMAXPROCS")
+		})
+	})
+
+	t.Run("ErrorReadingQuota", func(t *testing.T) {
+		opt := stubProcs(func(int) (int, iruntime.CPUQuotaStatus, error) {
+			return 0, iruntime.CPUQuotaUndefined, errors.New("failed")
+		})
+		prev := currentMaxProcs()
+		undo, err := Set(opt)
+		defer undo()
+		require.Error(t, err, "Set should have failed")
+		assert.Equal(t, "failed", err.Error(), "should pass errors up the stack")
+		assert.Equal(t, prev, currentMaxProcs(), "shouldn't alter GOMAXPROCS")
+	})
+
+	t.Run("QuotaUndefined", func(t *testing.T) {
+		buf, logOpt := testLogger()
+		quotaOpt := stubProcs(func(int) (int, iruntime.CPUQuotaStatus, error) {
+			return 0, iruntime.CPUQuotaUndefined, nil
+		})
+		prev := currentMaxProcs()
+		undo, err := Set(logOpt, quotaOpt)
+		defer undo()
+		require.NoError(t, err, "Set failed")
+		assert.Equal(t, prev, currentMaxProcs(), "shouldn't alter GOMAXPROCS")
+		assert.Contains(t, buf.String(), "quota undefined", "unexpected log output")
+	})
+
+	t.Run("QuotaTooSmall", func(t *testing.T) {
+		buf, logOpt := testLogger()
+		quotaOpt := stubProcs(func(min int) (int, iruntime.CPUQuotaStatus, error) {
+			return min, iruntime.CPUQuotaMinUsed, nil
+		})
+		undo, err := Set(logOpt, quotaOpt)
+		defer undo()
+		require.NoError(t, err, "Set failed")
+		assert.Equal(t, iruntime.MinGOMAXPROCS, currentMaxProcs(), "should use min allowed GOMAXPROCS")
+		assert.Contains(t, buf.String(), "using minimum allowed", "unexpected log output")
+	})
+
+	t.Run("QuotaUsed", func(t *testing.T) {
+		opt := stubProcs(func(min int) (int, iruntime.CPUQuotaStatus, error) {
+			return 42, iruntime.CPUQuotaUsed, nil
+		})
+		undo, err := Set(opt)
+		defer undo()
+		require.NoError(t, err, "Set failed")
+		assert.Equal(t, 42, currentMaxProcs(), "should change GOMAXPROCS to match quota")
+	})
+}

--- a/example_test.go
+++ b/example_test.go
@@ -18,6 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package automaxprocs lets Go programs easily configure runtime.GOMAXPROCS
-// to match the configured Linux CPU quota.
-package automaxprocs // import "go.uber.org/automaxprocs"
+package automaxprocs_test
+
+import (
+	"log"
+
+	"go.uber.org/automaxprocs"
+)
+
+func Example() {
+	undo, err := automaxprocs.Set()
+	defer undo()
+	if err != nil {
+		log.Fatalf("failed to set GOMAXPROCS: %v", err)
+	}
+	// Insert your application logic here.
+}
+
+func ExampleLogger() {
+	// By default, Set doesn't output any logs. You can enable logging by
+	// supplying a printf implementation.
+	undo, err := automaxprocs.Set(automaxprocs.Logger(log.Printf))
+	defer undo()
+	if err != nil {
+		log.Fatalf("failed to set GOMAXPROCS: %v", err)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -20,27 +20,8 @@
 
 package automaxprocs_test
 
-import (
-	"log"
-
-	"go.uber.org/automaxprocs"
-)
+import _ "go.uber.org/automaxprocs"
 
 func Example() {
-	undo, err := automaxprocs.Set()
-	defer undo()
-	if err != nil {
-		log.Fatalf("failed to set GOMAXPROCS: %v", err)
-	}
 	// Insert your application logic here.
-}
-
-func ExampleLogger() {
-	// By default, Set doesn't output any logs. You can enable logging by
-	// supplying a printf implementation.
-	undo, err := automaxprocs.Set(automaxprocs.Logger(log.Printf))
-	defer undo()
-	if err != nil {
-		log.Fatalf("failed to set GOMAXPROCS: %v", err)
-	}
 }

--- a/maxprocs/example_test.go
+++ b/maxprocs/example_test.go
@@ -18,6 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package automaxprocs lets Go programs easily configure runtime.GOMAXPROCS
-// to match the configured Linux CPU quota.
-package automaxprocs // import "go.uber.org/automaxprocs"
+package maxprocs_test
+
+import (
+	"log"
+
+	"go.uber.org/automaxprocs/maxprocs"
+)
+
+func Example() {
+	undo, err := maxprocs.Set()
+	defer undo()
+	if err != nil {
+		log.Fatalf("failed to set GOMAXPROCS: %v", err)
+	}
+	// Insert your application logic here.
+}
+
+func ExampleLogger() {
+	// By default, Set doesn't output any logs. You can enable logging by
+	// supplying a printf implementation.
+	undo, err := maxprocs.Set(maxprocs.Logger(log.Printf))
+	defer undo()
+	if err != nil {
+		log.Fatalf("failed to set GOMAXPROCS: %v", err)
+	}
+}

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package maxprocs lets Go programs easily configure runtime.GOMAXPROCS to
+// match the configured Linux CPU quota. Unlike the top-level automaxprocs
+// package, it lets the caller configure logging and handle errors.
+package maxprocs // import "go.uber.org/automaxprocs/maxprocs"
+
+import (
+	"os"
+	"runtime"
+
+	iruntime "go.uber.org/automaxprocs/internal/runtime"
+)
+
+const _maxProcsKey = "GOMAXPROCS"
+
+func currentMaxProcs() int {
+	return runtime.GOMAXPROCS(0)
+}
+
+type config struct {
+	printf func(string, ...interface{})
+	procs  func(int) (int, iruntime.CPUQuotaStatus, error)
+}
+
+func (c *config) log(fmt string, args ...interface{}) {
+	if c.printf != nil {
+		c.printf(fmt, args...)
+	}
+}
+
+// An Option alters the behavior of Set.
+type Option interface {
+	apply(*config)
+}
+
+// Logger uses the supplied printf implementation for log output. By default,
+// Set doesn't log anything.
+func Logger(printf func(string, ...interface{})) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.printf = printf
+	})
+}
+
+type optionFunc func(*config)
+
+func (of optionFunc) apply(cfg *config) { of(cfg) }
+
+// Set GOMAXPROCS to match the Linux container CPU quota (if any), returning
+// any error encountered and an undo function.
+//
+// Set is a no-op on non-Linux systems and in Linux environments without a
+// configured CPU quota.
+func Set(opts ...Option) (func(), error) {
+	cfg := &config{procs: iruntime.CPUQuotaToGOMAXPROCS}
+	for _, o := range opts {
+		o.apply(cfg)
+	}
+
+	prev := currentMaxProcs()
+	undo := func() {
+		cfg.log("resetting GOMAXPROCS to %d", prev)
+		runtime.GOMAXPROCS(prev)
+	}
+
+	// Honor the GOMAXPROCS environment variable if present. Otherwise, amend
+	// `runtime.GOMAXPROCS()` with the current process' CPU quota if the OS is
+	// Linux, and guarantee a minimum value of 2 to ensure efficiency.
+	if max, exists := os.LookupEnv(_maxProcsKey); exists {
+		cfg.log("GOMAXPROCS=%d: honoring explicitly-configured GOMAXPROCS from environment", max)
+		return undo, nil
+	}
+
+	maxProcs, status, err := cfg.procs(iruntime.MinGOMAXPROCS)
+	switch {
+	case err != nil:
+		return undo, err
+	case status == iruntime.CPUQuotaUndefined:
+		cfg.log("GOMAXPROCS=%d: CPU quota undefined", currentMaxProcs())
+	case status == iruntime.CPUQuotaMinUsed:
+		cfg.log("GOMAXPROCS=%d: using minimum allowed GOMAXPROCS", currentMaxProcs())
+	default:
+		cfg.log("GOMAXPROCS=%d: determined from CPU quota", currentMaxProcs())
+	}
+
+	runtime.GOMAXPROCS(maxProcs)
+	return undo, nil
+}

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package automaxprocs
+package maxprocs
 
 import (
 	"bytes"


### PR DESCRIPTION
The current package API is both rigid and difficult to test; in general,
we should avoid exposing complex functionality *only* via import-time
side-effects.

This PR refactors the package API to be more testable and flexible, and
then adds a code sample to the README, some testable examples, and
enough tests to get 100% coverage on the main package.

(I'll follow up with a diff to our internal version of this package;
this API should allow us to make that change fully backward-compatible.)