### PR TITLE
Unset $GOMAXPROCS during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dependencies:
 	glide install
 ifdef SHOULD_LINT
 	@echo "Installing golint..."
-	go install ./vendor/github.com/golang/lint/golint
+	go get -u github.com/golang/lint/golint
 else
 	@echo "Not installing golint, since we don't expect to lint on" $(GO_VERSION)
 endif

--- a/glide.lock
+++ b/glide.lock
@@ -1,15 +1,11 @@
-hash: 21763d7fd44e410d44acb83a834a2c3e40a2b6ded096b516bf155a3246dc7e56
-updated: 2017-08-07T15:47:07.28565671-07:00
+hash: fb5fac279b3b5a551b2baba2f1e423c3ce8d60b6b2a6d5ed5c03760ffa568993
+updated: 2017-08-09T09:29:17.043339849-07:00
 imports: []
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
-- name: github.com/golang/lint
-  version: c5fb716d6688a859aae56d26d3e6070808df29f7
-  subpackages:
-  - golint
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -18,3 +14,4 @@ testImports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,6 @@
 package: go.uber.org/automaxprocs
 import: []
 testImport:
-- package: github.com/golang/lint/golint
 - package: github.com/stretchr/testify
   version: ^1.1.4
   subpackages:

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"testing"
@@ -143,18 +144,8 @@ func TestSet(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	prev, ok := os.LookupEnv(_maxProcsKey)
 	if err := os.Unsetenv(_maxProcsKey); err != nil {
-		fmt.Printf("Couldn't clear %s: %v\n", _maxProcsKey, err)
-		os.Exit(1)
+		log.Fatalf("Couldn't clear %s: %v\n", _maxProcsKey, err)
 	}
-
-	code := m.Run()
-	if ok {
-		if err := os.Setenv(_maxProcsKey, prev); err != nil {
-			fmt.Printf("Couldn't restore %s to %s: %v\n", _maxProcsKey, prev, err)
-			os.Exit(1)
-		}
-	}
-	os.Exit(code)
+	os.Exit(m.Run())
 }

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -141,3 +141,20 @@ func TestSet(t *testing.T) {
 		assert.Equal(t, 42, currentMaxProcs(), "should change GOMAXPROCS to match quota")
 	})
 }
+
+func TestMain(m *testing.M) {
+	prev, ok := os.LookupEnv(_maxProcsKey)
+	if err := os.Unsetenv(_maxProcsKey); err != nil {
+		fmt.Printf("Couldn't clear %s: %v\n", _maxProcsKey, err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	if ok {
+		if err := os.Setenv(_maxProcsKey, prev); err != nil {
+			fmt.Printf("Couldn't restore %s to %s: %v\n", _maxProcsKey, prev, err)
+			os.Exit(1)
+		}
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
In order to test the `maxprocs` package, we need to control the value of
`$GOMAXPROCS`. Unfortunately, Travis sets `$GOMAXPROCS` in every
container.

To work around this, use `TestMain` to unset `$GOMAXPROCS` for the
`maxprocs` package tests, restoring the previous value after tests
complete.