### PR TITLE
Refactor maxprocs: better logging and only set on success

### DIFF
--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -75,7 +75,7 @@ func Set(opts ...Option) (func(), error) {
 		o.apply(cfg)
 	}
 
-	undo := func() {
+	undoNoop := func() {
 		cfg.log("maxprocs: No GOMAXPROCS change to reset")
 	}
 
@@ -84,21 +84,21 @@ func Set(opts ...Option) (func(), error) {
 	// Linux, and guarantee a minimum value of 2 to ensure efficiency.
 	if max, exists := os.LookupEnv(_maxProcsKey); exists {
 		cfg.log("maxprocs: Honoring GOMAXPROCS=%d as set in environment", max)
-		return undo, nil
+		return undoNoop, nil
 	}
 
 	maxProcs, status, err := cfg.procs(iruntime.MinGOMAXPROCS)
 	if err != nil {
-		return undo, err
+		return undoNoop, err
 	}
 
 	if status == iruntime.CPUQuotaUndefined {
 		cfg.log("maxprocs: Leaving GOMAXPROCS=%d: CPU quota undefined", currentMaxProcs())
-		return undo, nil
+		return undoNoop, nil
 	}
 
 	prev := currentMaxProcs()
-	undo = func() {
+	undo := func() {
 		cfg.log("maxprocs: Resetting GOMAXPROCS to %d", prev)
 		runtime.GOMAXPROCS(prev)
 	}

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -120,6 +120,19 @@ func TestSet(t *testing.T) {
 		assert.Contains(t, buf.String(), "quota undefined", "unexpected log output")
 	})
 
+	t.Run("QuotaUndefined return maxProcs=7", func(t *testing.T) {
+		buf, logOpt := testLogger()
+		quotaOpt := stubProcs(func(int) (int, iruntime.CPUQuotaStatus, error) {
+			return 7, iruntime.CPUQuotaUndefined, nil
+		})
+		prev := currentMaxProcs()
+		undo, err := Set(logOpt, quotaOpt)
+		defer undo()
+		require.NoError(t, err, "Set failed")
+		assert.Equal(t, prev, currentMaxProcs(), "shouldn't alter GOMAXPROCS")
+		assert.Contains(t, buf.String(), "quota undefined", "unexpected log output")
+	})
+
 	t.Run("QuotaTooSmall", func(t *testing.T) {
 		buf, logOpt := testLogger()
 		quotaOpt := stubProcs(func(min int) (int, iruntime.CPUQuotaStatus, error) {


### PR DESCRIPTION
Currently, we call `GOMAXPROCS` even if we are unable to determine the
CPU quota. Since the returned value is 0, this doesn't have an impact,
but avoid calling `runtime.GOMAXPROCS` to set the value unless we
successfully determine the quota.

Improve logging so users have clear messaging about the source of logs
(maxprocs) and what is being changed (are we ignoring, updating, etc)
and make all the messages more consistent.