### PR TITLE
Minimum GOMAXPROCS should be 1

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -31,6 +31,3 @@ const (
 	// CPUQuotaMinUsed is return when CPU quota is larger than the min value
 	CPUQuotaMinUsed
 )
-
-// MinGOMAXPROCS defines the minimum value for GOMAXPROCS
-const MinGOMAXPROCS = 2

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -62,6 +62,7 @@ func Logger(printf func(string, ...interface{})) Option {
 }
 
 // Min sets the minimum GOMAXPROCS value that will be used.
+// Any value below 1 is ignored.
 func Min(n int) Option {
 	return optionFunc(func(cfg *config) {
 		if n >= 1 {

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -64,7 +64,9 @@ func Logger(printf func(string, ...interface{})) Option {
 // Min sets the minimum GOMAXPROCS value that will be used.
 func Min(n int) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.minGOMAXPROCS = n
+		if n >= 1 {
+			cfg.minGOMAXPROCS = n
+		}
 	})
 }
 

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -138,15 +138,16 @@ func TestSet(t *testing.T) {
 		quotaOpt := stubProcs(func(min int) (int, iruntime.CPUQuotaStatus, error) {
 			return min, iruntime.CPUQuotaMinUsed, nil
 		})
-		undo, err := Set(logOpt, quotaOpt)
+		undo, err := Set(logOpt, quotaOpt, Min(5))
 		defer undo()
 		require.NoError(t, err, "Set failed")
-		assert.Equal(t, iruntime.MinGOMAXPROCS, currentMaxProcs(), "should use min allowed GOMAXPROCS")
+		assert.Equal(t, 5, currentMaxProcs(), "should use min allowed GOMAXPROCS")
 		assert.Contains(t, buf.String(), "using minimum allowed", "unexpected log output")
 	})
 
 	t.Run("QuotaUsed", func(t *testing.T) {
 		opt := stubProcs(func(min int) (int, iruntime.CPUQuotaStatus, error) {
+			assert.Equal(t, 1, min, "Default minimum value should be 1")
 			return 42, iruntime.CPUQuotaUsed, nil
 		})
 		undo, err := Set(opt)

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -145,6 +145,19 @@ func TestSet(t *testing.T) {
 		assert.Contains(t, buf.String(), "using minimum allowed", "unexpected log output")
 	})
 
+	t.Run("Min unused", func(t *testing.T) {
+		buf, logOpt := testLogger()
+		quotaOpt := stubProcs(func(min int) (int, iruntime.CPUQuotaStatus, error) {
+			return min, iruntime.CPUQuotaMinUsed, nil
+		})
+		// Min(-1) should be ignored.
+		undo, err := Set(logOpt, quotaOpt, Min(5), Min(-1))
+		defer undo()
+		require.NoError(t, err, "Set failed")
+		assert.Equal(t, 5, currentMaxProcs(), "should use min allowed GOMAXPROCS")
+		assert.Contains(t, buf.String(), "using minimum allowed", "unexpected log output")
+	})
+
 	t.Run("QuotaUsed", func(t *testing.T) {
 		opt := stubProcs(func(min int) (int, iruntime.CPUQuotaStatus, error) {
 			assert.Equal(t, 1, min, "Default minimum value should be 1")


### PR DESCRIPTION
We previously set the minimum GOMAXPROCS value to 2 as that was the
minimum allocation we expected internally. However, if the allocation is
actually smaller, we should use lower GOMAXPROCS.

This will also allow us to reduce the allocation size and use a more
appropriate GOMAXPROCS which will reduce the amount of CFS throttling.