### PR TITLE
Fix example rendering

### DIFF
--- a/automaxprocs.go
+++ b/automaxprocs.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package automaxprocs automatically sets `GOMAXPROCS` to match Linux
+// Package automaxprocs automatically sets GOMAXPROCS to match the Linux
 // container CPU quota, if any.
 package automaxprocs // import "go.uber.org/automaxprocs"
 

--- a/example_test.go
+++ b/example_test.go
@@ -20,8 +20,10 @@
 
 package automaxprocs_test
 
+// Importing automaxprocs automatically adjusts GOMAXPROCS.
 import _ "go.uber.org/automaxprocs"
 
-func Example() {
-	// Insert your application logic here.
-}
+// To render a whole-file example, we need a package-level declaration.
+var _ = ""
+
+func Example() {}


### PR DESCRIPTION
In order to render a whole-file example, we need at least one
package-level declaration.