### PR TITLE
Use floor(quota) rather than ceil(quota)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.0 (unreleased)
+
+- Fixed quota clamping to always round down rather than up; Rather than
+  guaranteeing constant throttling at saturation, instead assume that the
+  fractional CPU was added as a hedge for factors outside of Go's scheduler.
+
 ## v1.1.0 (2017-11-10)
 
 - Log the new value of `GOMAXPROCS` rather than the current value.

--- a/internal/runtime/cpu_quota_linux.go
+++ b/internal/runtime/cpu_quota_linux.go
@@ -41,7 +41,7 @@ func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
 		return -1, CPUQuotaUndefined, err
 	}
 
-	maxProcs := int(math.Ceil(quota))
+	maxProcs := int(math.Floor(quota))
 	if minValue > 0 && maxProcs < minValue {
 		return minValue, CPUQuotaMinUsed, nil
 	}


### PR DESCRIPTION
Apologies, this was an oversight on my part back when we wrote the `x/runtime` precursor that I helped to review. I'd since been working on the (it turns out false) assumption that this had been floor all along. Recent investigation into pervasive low-grade throttling tho led me to this discovery.

In short:
- as far as the Go scheduler is concerned, there's no such thing as a fractional CPU
- so let's say you have your quota set to `N + p` for some integer `N` and some `0.0 < p < 1.0`
- the only safe assumption then is that you're using that `p` value as a hedge for something like "systems effects" or "c libraries"
  - in that latter case, what you really might want to be able give maxprocs some value `K` of reserved CPUs for some parasite like a C library or sidecar; but that's probably more of an option for our Fx wrapper?