### PR TITLE
Add a Reserved option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.0 (unreleased)
+
+- Add a `Reserved(quota float64)` option to allow users to reserve part of
+  their CPU quota things outside the Go runtime.
+
 ## v1.1.0 (2017-11-10)
 
 - Log the new value of `GOMAXPROCS` rather than the current value.

--- a/internal/runtime/cpu_quota_linux.go
+++ b/internal/runtime/cpu_quota_linux.go
@@ -41,9 +41,14 @@ func CPUQuotaToGOMAXPROCS(cfg CPUQuotaConfig) (int, CPUQuotaStatus, error) {
 		return -1, CPUQuotaUndefined, err
 	}
 
+	if cfg.Reserved > 0 {
+		quota -= cfg.Reserved
+	}
+
 	maxProcs := int(math.Ceil(quota))
 	if cfg.MinValue > 0 && maxProcs < cfg.MinValue {
 		return cfg.MinValue, CPUQuotaMinUsed, nil
 	}
+
 	return maxProcs, CPUQuotaUsed, nil
 }

--- a/internal/runtime/cpu_quota_linux.go
+++ b/internal/runtime/cpu_quota_linux.go
@@ -30,7 +30,7 @@ import (
 
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value.
-func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
+func CPUQuotaToGOMAXPROCS(cfg CPUQuotaConfig) (int, CPUQuotaStatus, error) {
 	cgroups, err := cg.NewCGroupsForCurrentProcess()
 	if err != nil {
 		return -1, CPUQuotaUndefined, err
@@ -42,8 +42,8 @@ func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
 	}
 
 	maxProcs := int(math.Ceil(quota))
-	if minValue > 0 && maxProcs < minValue {
-		return minValue, CPUQuotaMinUsed, nil
+	if cfg.MinValue > 0 && maxProcs < cfg.MinValue {
+		return cfg.MinValue, CPUQuotaMinUsed, nil
 	}
 	return maxProcs, CPUQuotaUsed, nil
 }

--- a/internal/runtime/cpu_quota_unsupported.go
+++ b/internal/runtime/cpu_quota_unsupported.go
@@ -25,6 +25,6 @@ package runtime
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value. This is Linux-specific and not supported in the
 // current OS.
-func CPUQuotaToGOMAXPROCS(_ int) (int, CPUQuotaStatus, error) {
+func CPUQuotaToGOMAXPROCS(_ CPUQuotaConfig) (int, CPUQuotaStatus, error) {
 	return -1, CPUQuotaUndefined, nil
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -32,9 +32,15 @@ const (
 	CPUQuotaMinUsed
 )
 
+// CPUQuotaConfig specifies configured constraints for automatic GOMAXPROCS
+// configuration.
+type CPUQuotaConfig struct {
+	MinValue int
+}
+
 // CPUQuotaFunc represents a strategy for auto-configuring MAXPROCS based on
 // CPU quota based on configured constraints and environmental data.
-type CPUQuotaFunc func(minValue int) (
+type CPUQuotaFunc func(CPUQuotaConfig) (
 	maxprocs int,
 	status CPUQuotaStatus,
 	err error,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -31,3 +31,11 @@ const (
 	// CPUQuotaMinUsed is return when CPU quota is larger than the min value
 	CPUQuotaMinUsed
 )
+
+// CPUQuotaFunc represents a strategy for auto-configuring MAXPROCS based on
+// CPU quota based on configured constraints and environmental data.
+type CPUQuotaFunc func(minValue int) (
+	maxprocs int,
+	status CPUQuotaStatus,
+	err error,
+)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -36,6 +36,7 @@ const (
 // configuration.
 type CPUQuotaConfig struct {
 	MinValue int
+	Reserved float64
 }
 
 // CPUQuotaFunc represents a strategy for auto-configuring MAXPROCS based on

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -83,7 +83,7 @@ func (c config) undo() {
 // Set is a no-op on non-Linux systems and in Linux environments without a
 // configured CPU quota.
 func Set(opts ...Option) (func(), error) {
-	cfg := &config{
+	cfg := config{
 		log:       noopLog,
 		quotaFunc: iruntime.CPUQuotaToGOMAXPROCS,
 		CPUQuotaConfig: iruntime.CPUQuotaConfig{
@@ -91,7 +91,7 @@ func Set(opts ...Option) (func(), error) {
 		},
 	}
 	for _, o := range opts {
-		o.apply(cfg)
+		o.apply(&cfg)
 	}
 
 	// Honor the GOMAXPROCS environment variable if present. Otherwise, amend

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -32,10 +32,6 @@ import (
 
 const _maxProcsKey = "GOMAXPROCS"
 
-func currentMaxProcs() int {
-	return runtime.GOMAXPROCS(0)
-}
-
 type config struct {
 	printf        func(string, ...interface{})
 	procs         func(int) (int, iruntime.CPUQuotaStatus, error)
@@ -106,7 +102,7 @@ func Set(opts ...Option) (func(), error) {
 		return undoNoop, err
 	}
 
-	prev := currentMaxProcs()
+	prev := runtime.GOMAXPROCS(0)
 
 	if status == iruntime.CPUQuotaUndefined {
 		cfg.log("maxprocs: Leaving GOMAXPROCS=%d: CPU quota undefined", prev)

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -32,16 +32,12 @@ import (
 
 const _maxProcsKey = "GOMAXPROCS"
 
+func noopLog(fmt string, args ...interface{}) {}
+
 type config struct {
-	printf        func(string, ...interface{})
+	log           func(string, ...interface{})
 	procs         func(int) (int, iruntime.CPUQuotaStatus, error)
 	minGOMAXPROCS int
-}
-
-func (c *config) log(fmt string, args ...interface{}) {
-	if c.printf != nil {
-		c.printf(fmt, args...)
-	}
 }
 
 // An Option alters the behavior of Set.
@@ -53,7 +49,7 @@ type Option interface {
 // Set doesn't log anything.
 func Logger(printf func(string, ...interface{})) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.printf = printf
+		cfg.log = printf
 	})
 }
 
@@ -78,6 +74,7 @@ func (of optionFunc) apply(cfg *config) { of(cfg) }
 // configured CPU quota.
 func Set(opts ...Option) (func(), error) {
 	cfg := &config{
+		log:           noopLog,
 		procs:         iruntime.CPUQuotaToGOMAXPROCS,
 		minGOMAXPROCS: 1,
 	}

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -64,6 +64,22 @@ func Min(n int) Option {
 	})
 }
 
+// ReservedCPUQuota specifies a CPU quota amount to consider reserved for use
+// outside of the Go runtime; e.g. by a cgo extension, or another process
+// within the container.
+//
+// GOMAXPROCS will be set to the remaining (rounded down) quota, clamped to the
+// minimum limit (default 1).
+//
+// Any non-positive value is ignored.
+func ReservedCPUQuota(reserved float64) Option {
+	return optionFunc(func(cfg *config) {
+		if reserved >= 0 {
+			cfg.Reserved = reserved
+		}
+	})
+}
+
 type optionFunc func(*config)
 
 func (of optionFunc) apply(cfg *config) { of(cfg) }

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -36,7 +36,7 @@ func noopLog(fmt string, args ...interface{}) {}
 
 type config struct {
 	log           func(string, ...interface{})
-	procs         func(int) (int, iruntime.CPUQuotaStatus, error)
+	quotaFunc     iruntime.CPUQuotaFunc
 	minGOMAXPROCS int
 }
 
@@ -75,7 +75,7 @@ func (of optionFunc) apply(cfg *config) { of(cfg) }
 func Set(opts ...Option) (func(), error) {
 	cfg := &config{
 		log:           noopLog,
-		procs:         iruntime.CPUQuotaToGOMAXPROCS,
+		quotaFunc:     iruntime.CPUQuotaToGOMAXPROCS,
 		minGOMAXPROCS: 1,
 	}
 	for _, o := range opts {
@@ -94,7 +94,7 @@ func Set(opts ...Option) (func(), error) {
 		return undoNoop, nil
 	}
 
-	maxProcs, status, err := cfg.procs(cfg.minGOMAXPROCS)
+	maxProcs, status, err := cfg.quotaFunc(cfg.minGOMAXPROCS)
 	if err != nil {
 		return undoNoop, err
 	}

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -106,12 +106,13 @@ func Set(opts ...Option) (func(), error) {
 		return undoNoop, err
 	}
 
+	prev := currentMaxProcs()
+
 	if status == iruntime.CPUQuotaUndefined {
-		cfg.log("maxprocs: Leaving GOMAXPROCS=%d: CPU quota undefined", currentMaxProcs())
+		cfg.log("maxprocs: Leaving GOMAXPROCS=%d: CPU quota undefined", prev)
 		return undoNoop, nil
 	}
 
-	prev := currentMaxProcs()
 	undo := func() {
 		cfg.log("maxprocs: Resetting GOMAXPROCS to %d", prev)
 		runtime.GOMAXPROCS(prev)

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -97,7 +97,7 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("ErrorReadingQuota", func(t *testing.T) {
-		opt := stubQuotaFunc(func(int) (int, iruntime.CPUQuotaStatus, error) {
+		opt := stubQuotaFunc(func(iruntime.CPUQuotaConfig) (int, iruntime.CPUQuotaStatus, error) {
 			return 0, iruntime.CPUQuotaUndefined, errors.New("failed")
 		})
 		prev := runtime.GOMAXPROCS(0)
@@ -110,7 +110,7 @@ func TestSet(t *testing.T) {
 
 	t.Run("QuotaUndefined", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubQuotaFunc(func(int) (int, iruntime.CPUQuotaStatus, error) {
+		quotaOpt := stubQuotaFunc(func(iruntime.CPUQuotaConfig) (int, iruntime.CPUQuotaStatus, error) {
 			return 0, iruntime.CPUQuotaUndefined, nil
 		})
 		prev := runtime.GOMAXPROCS(0)
@@ -123,7 +123,7 @@ func TestSet(t *testing.T) {
 
 	t.Run("QuotaUndefined return maxProcs=7", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubQuotaFunc(func(int) (int, iruntime.CPUQuotaStatus, error) {
+		quotaOpt := stubQuotaFunc(func(iruntime.CPUQuotaConfig) (int, iruntime.CPUQuotaStatus, error) {
 			return 7, iruntime.CPUQuotaUndefined, nil
 		})
 		prev := runtime.GOMAXPROCS(0)
@@ -136,8 +136,8 @@ func TestSet(t *testing.T) {
 
 	t.Run("QuotaTooSmall", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubQuotaFunc(func(min int) (int, iruntime.CPUQuotaStatus, error) {
-			return min, iruntime.CPUQuotaMinUsed, nil
+		quotaOpt := stubQuotaFunc(func(cfg iruntime.CPUQuotaConfig) (int, iruntime.CPUQuotaStatus, error) {
+			return cfg.MinValue, iruntime.CPUQuotaMinUsed, nil
 		})
 		undo, err := Set(logOpt, quotaOpt, Min(5))
 		defer undo()
@@ -148,8 +148,8 @@ func TestSet(t *testing.T) {
 
 	t.Run("Min unused", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubQuotaFunc(func(min int) (int, iruntime.CPUQuotaStatus, error) {
-			return min, iruntime.CPUQuotaMinUsed, nil
+		quotaOpt := stubQuotaFunc(func(cfg iruntime.CPUQuotaConfig) (int, iruntime.CPUQuotaStatus, error) {
+			return cfg.MinValue, iruntime.CPUQuotaMinUsed, nil
 		})
 		// Min(-1) should be ignored.
 		undo, err := Set(logOpt, quotaOpt, Min(5), Min(-1))
@@ -160,8 +160,8 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("QuotaUsed", func(t *testing.T) {
-		opt := stubQuotaFunc(func(min int) (int, iruntime.CPUQuotaStatus, error) {
-			assert.Equal(t, 1, min, "Default minimum value should be 1")
+		opt := stubQuotaFunc(func(cfg iruntime.CPUQuotaConfig) (int, iruntime.CPUQuotaStatus, error) {
+			assert.Equal(t, 1, cfg.MinValue, "Default minimum value should be 1")
 			return 42, iruntime.CPUQuotaUsed, nil
 		})
 		undo, err := Set(opt)


### PR DESCRIPTION
Okay, after offline discussion with @prashantv and @akshayjshah, here's an addendum to #13:
- adds a `Reserved(q float64)` option that can be used to not allocate all of the CPU quota to `GOMAXPROCS`
- intentionally left room, per discussion with @akshayjshah, so that we can more easily choose to add an option that takes some sort of a custom strategy func (i.e. maybe a `func(func(quota float64, config CPUQuotaConfig) (int, CPUQuotaStatus)) Option`)
- based this branch off master, so we cane choose whether to have (some version) of it and/or #13 

Questions I have for reviewers at the outset:
- would you prefer much of the prep work broken out from the introduction of `Reserved`?
- would you rather just externalize some rendition of the internal runtime types and jump to a more generic strategy-func option?