### PR TITLE
Preparing release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.0 (2020-01-23)
+
+- Migrate to Go modules.
+
 ## v1.2.0 (2018-02-22)
 
 - Fixed quota clamping to always round down rather than up; Rather than

--- a/maxprocs/version.go
+++ b/maxprocs/version.go
@@ -21,4 +21,4 @@
 package maxprocs
 
 // Version is the current package version.
-const Version = "1.2.0"
+const Version = "1.3.0"


### PR DESCRIPTION
This releases v1.3.0 of automaxprocs. The only change in this release is
the migration to Go modules.