### PR TITLE
Expose cpu quota

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,23 +25,12 @@ git remote add upstream https://github.com/uber-go/automaxprocs.git
 git fetch upstream
 ```
 
-Install the test dependencies:
-
-```
-make dependencies
-```
-
 Make sure that the tests and the linters pass:
 
 ```
 make test
 make lint
 ```
-
-If you're not using the minor version of Go specified in the Makefile's
-`LINTABLE_MINOR_VERSIONS` variable, `make lint` doesn't do anything. This is
-fine, but it means that you'll only discover lint failures after you open your
-pull request.
 
 ## Making Changes
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ $(STATICCHECK):
 
 .PHONY: lint
 lint: $(GOLINT) $(STATICCHECK)
+    # avoid `go vet` output going to lint.log on fresh clone
+	@go build ./...
+	@go test ./...
 	@rm -rf lint.log
 	@echo "Checking gofmt"
 	@gofmt -d -s $(GO_FILES) 2>&1 | tee lint.log

--- a/README.md
+++ b/README.md
@@ -1,19 +1,35 @@
 # automaxprocs [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-Automatically set `GOMAXPROCS` to match Linux container CPU quota.
+# automaxprocs
 
-## Installation
-
-`go get -u go.uber.org/automaxprocs`
+Importing the base package will automatically set `GOMAXPROCS` to match Linux container
+CPU quota.
 
 ## Quick Start
 
+To automatically set `GOMAXPROCS`:
 ```go
 import _ "go.uber.org/automaxprocs"
 
 func main() {
   // Your application logic here.
 }
+```
+
+To get the current CPU quota
+```go
+import "go.uber.org/automaxprocs/cpuquota"
+
+allCGroups, err := cpuquota.NewCGroupsForCurrentProcess()
+if err != nil {
+	// handle err
+}
+quota, defined, err := allCGroups.CPUQuota()
+if !defined || err != nil {
+	// handle err
+}
+
+fmt.Println("quota:", quota)
 ```
 
 ## Development Status: Stable
@@ -42,5 +58,3 @@ Released under the [MIT License](LICENSE).
 [ci]: https://travis-ci.com/uber-go/automaxprocs
 [cov-img]: https://codecov.io/gh/uber-go/automaxprocs/branch/master/graph/badge.svg
 [cov]: https://codecov.io/gh/uber-go/automaxprocs
-
-

--- a/cpuquota/cpuquota.go
+++ b/cpuquota/cpuquota.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cpuquota
+
+import "go.uber.org/automaxprocs/internal/cgroups"
+
+// NewCGroupsForCurrentProcess returns a new *CGroups instance for the current
+// process.
+func NewCGroupsForCurrentProcess() (cgroups.CGroups, error) {
+	return cgroups.NewCGroupsForCurrentProcess()
+}
+
+// CPUQuota returns the CPU quota applied with the CPU cgroup controller.
+// It is a result of `cpu.cfs_quota_us / cpu.cfs_period_us`. If the value of
+// `cpu.cfs_quota_us` was not set (-1), the method returns `(-1, nil)`.
+func CPUQuota(cg cgroups.CGroups) (float64, bool, error) {
+	return cg.CPUQuota()
+}


### PR DESCRIPTION
This PR exposes the api for querying the cpu quota.

The specific use case is when we need to specify the concurrency level (via cli arg) for a non-golang subprocess.