### PR TITLE
Add support for reading total memory

### DIFF
--- a/internal/cgroups/cgroups.go
+++ b/internal/cgroups/cgroups.go
@@ -43,7 +43,6 @@ const (
 	_cgroupCPUCFSPeriodUsParam = "cpu.cfs_period_us"
 	// _cgroupMemoryLimitBytes is the file name for CGroup total memory parameter.
 	_cgroupMemoryLimitBytes = "memory.limit_in_bytes"
-
 )
 
 const (

--- a/internal/cgroups/cgroups.go
+++ b/internal/cgroups/cgroups.go
@@ -41,6 +41,9 @@ const (
 	// _cgroupCPUCFSPeriodUsParam is the file name for the CGroup CFS period
 	// parameter.
 	_cgroupCPUCFSPeriodUsParam = "cpu.cfs_period_us"
+	// _cgroupMemoryLimitBytes is the file name for CGroup total memory parameter.
+	_cgroupMemoryLimitBytes = "memory.limit_in_bytes"
+
 )
 
 const (
@@ -114,4 +117,18 @@ func (cg CGroups) CPUQuota() (float64, bool, error) {
 	}
 
 	return float64(cfsQuotaUs) / float64(cfsPeriodUs), true, nil
+}
+
+// TotalMemoryQuota returns total memory quota from `memory.limit_in_bytes`.
+func (cg CGroups) TotalMemoryQuota() (int64, bool, error) {
+	cpuCGroup, exists := cg[_cgroupSubsysMemory]
+	if !exists {
+		return -1, false, nil
+	}
+
+	memLimitBytes, err := cpuCGroup.readInt(_cgroupMemoryLimitBytes)
+	if defined := memLimitBytes > 0; err != nil || !defined {
+		return -1, defined, err
+	}
+	return int64(memLimitBytes), true, nil
 }

--- a/internal/cgroups/cgroups_test.go
+++ b/internal/cgroups/cgroups_test.go
@@ -23,11 +23,11 @@
 package cgroups
 
 import (
-	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCGroups(t *testing.T) {

--- a/internal/cgroups/cgroups_test.go
+++ b/internal/cgroups/cgroups_test.go
@@ -23,6 +23,7 @@
 package cgroups
 
 import (
+	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"testing"
 
@@ -130,4 +131,13 @@ func TestCGroupsCPUQuota(t *testing.T) {
 			assert.NoError(t, err, tt.name)
 		}
 	}
+}
+
+func TestTotalMemory(t *testing.T) {
+	cgroups, err := NewCGroupsForCurrentProcess()
+	require.NoError(t, err)
+	quota, defined, err := cgroups.TotalMemoryQuota()
+	require.NoError(t, err)
+	assert.Equal(t, true, defined)
+	assert.True(t, quota > 0)
 }

--- a/internal/runtime/cpu_quota_unsupported.go
+++ b/internal/runtime/cpu_quota_unsupported.go
@@ -28,3 +28,8 @@ package runtime
 func CPUQuotaToGOMAXPROCS(_ int) (int, CPUQuotaStatus, error) {
 	return -1, CPUQuotaUndefined, nil
 }
+
+// TotalMemory returns total available memory.
+func TotalMemory() (int64, TotalMemoryStatus, error) {
+	return -1, TotalMemoryUndefined, nil
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -23,7 +23,7 @@ package runtime
 // CPUQuotaStatus presents the status of how CPU quota is used
 type CPUQuotaStatus int
 
-// TotalMemory presents the status of how total memory quota is used
+// TotalMemoryStatus presents the status of how total memory quota is used
 type TotalMemoryStatus int
 
 const (

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -23,6 +23,9 @@ package runtime
 // CPUQuotaStatus presents the status of how CPU quota is used
 type CPUQuotaStatus int
 
+// TotalMemory presents the status of how total memory quota is used
+type TotalMemoryStatus int
+
 const (
 	// CPUQuotaUndefined is returned when CPU quota is undefined
 	CPUQuotaUndefined CPUQuotaStatus = iota
@@ -30,4 +33,9 @@ const (
 	CPUQuotaUsed
 	// CPUQuotaMinUsed is return when CPU quota is smaller than the min value
 	CPUQuotaMinUsed
+
+	// TotalMemoryUndefined is returned when total memory is undefined
+	TotalMemoryUndefined TotalMemoryStatus = iota
+	// TotalMemoryUsed is returned when a valid total memory quota can be used
+	TotalMemoryUsed
 )

--- a/totalmemory/totalmemory_test.go
+++ b/totalmemory/totalmemory_test.go
@@ -21,9 +21,10 @@
 package totalmemory
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestTotalMemory(t *testing.T) {

--- a/totalmemory/totalmemory_test.go
+++ b/totalmemory/totalmemory_test.go
@@ -18,47 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// +build linux
-
-package runtime
+package totalmemory
 
 import (
-	"math"
-
-	cg "go.uber.org/automaxprocs/internal/cgroups"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
-// CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
-// to a valid GOMAXPROCS value.
-func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
-	cgroups, err := cg.NewCGroupsForCurrentProcess()
-	if err != nil {
-		return -1, CPUQuotaUndefined, err
-	}
-
-	quota, defined, err := cgroups.CPUQuota()
-	if !defined || err != nil {
-		return -1, CPUQuotaUndefined, err
-	}
-
-	maxProcs := int(math.Floor(quota))
-	if minValue > 0 && maxProcs < minValue {
-		return minValue, CPUQuotaMinUsed, nil
-	}
-	return maxProcs, CPUQuotaUsed, nil
-}
-
-// TotalMemory returns total available memory.
-func TotalMemory() (int64, TotalMemoryStatus, error) {
-	cgroups, err := cg.NewCGroupsForCurrentProcess()
-	if err != nil {
-		return -1, TotalMemoryUndefined, err
-	}
-
-	quota, defined, err := cgroups.TotalMemoryQuota()
-	if !defined || err != nil {
-		return -1, TotalMemoryUndefined, err
-	}
-
-	return quota, TotalMemoryUsed, nil
+func TestTotalMemory(t *testing.T) {
+	totalMemory, err := TotalMemory()
+	require.NoError(t, err)
+	assert.True(t, totalMemory > 0)
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Expose readings from `memory.limit_in_bytes` in the public API.