### PR TITLE
Fix mountpoint multiple match

### DIFF
--- a/internal/cgroups/cgroups_test.go
+++ b/internal/cgroups/cgroups_test.go
@@ -23,7 +23,6 @@
 package cgroups
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -48,7 +47,6 @@ func TestNewCGroups(t *testing.T) {
 	assert.Equal(t, len(testTable), len(cgroups))
 	assert.NoError(t, err)
 
-	fmt.Printf("cgroups :%v", cgroups)
 	for _, tt := range testTable {
 		cgroup, exists := cgroups[tt.subsys]
 		assert.Equal(t, true, exists, "%q expected to present in `cgroups`", tt.subsys)

--- a/internal/cgroups/cgroups_test.go
+++ b/internal/cgroups/cgroups_test.go
@@ -23,6 +23,7 @@
 package cgroups
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -47,6 +48,7 @@ func TestNewCGroups(t *testing.T) {
 	assert.Equal(t, len(testTable), len(cgroups))
 	assert.NoError(t, err)
 
+	fmt.Printf("cgroups :%v", cgroups)
 	for _, tt := range testTable {
 		cgroup, exists := cgroups[tt.subsys]
 		assert.Equal(t, true, exists, "%q expected to present in `cgroups`", tt.subsys)

--- a/internal/cgroups/mountpoint.go
+++ b/internal/cgroups/mountpoint.go
@@ -136,6 +136,14 @@ func (mp *MountPoint) Translate(absPath string) (string, error) {
 		return "", err
 	}
 
+	if relPath == ".." || strings.HasPrefix(relPath, "../") {
+		return "", pathNotExposedFromMountPointError{
+			mountPoint: mp.MountPoint,
+			root:       mp.Root,
+			path:       absPath,
+		}
+	}
+
 	return filepath.Join(mp.MountPoint, relPath), nil
 }
 

--- a/internal/cgroups/mountpoint.go
+++ b/internal/cgroups/mountpoint.go
@@ -107,7 +107,7 @@ func NewMountPointFromLine(line string) (*MountPoint, error) {
 			if len(rootOpts) == 0 {
 				return nil, mountPointFormatInvalidError{line}
 			}
-			superOpts := rootOpts[len(rootOpts)-1:]
+			superOpts := strings.Split(rootOpts[len(rootOpts)-1], _mountInfoOptsSep)
 
 			return &MountPoint{
 				MountID:        mountID,

--- a/internal/cgroups/mountpoint_test.go
+++ b/internal/cgroups/mountpoint_test.go
@@ -47,7 +47,7 @@ func TestNewMountPointFromLine(t *testing.T) {
 				OptionalFields: []string{},
 				FSType:         "ext4",
 				MountSource:    "/dev/dm-0",
-				SuperOptions:   []string{"rw", "errors=remount-ro", "data=ordered"},
+				SuperOptions:   []string{""},
 			},
 		},
 		{
@@ -63,7 +63,7 @@ func TestNewMountPointFromLine(t *testing.T) {
 				OptionalFields: []string{"shared:1"},
 				FSType:         "cgroup",
 				MountSource:    "cgroup",
-				SuperOptions:   []string{"rw", "cpu"},
+				SuperOptions:   []string{"cpu"},
 			},
 		},
 	}

--- a/internal/cgroups/testdata/proc/cgroups/mountinfo
+++ b/internal/cgroups/testdata/proc/cgroups/mountinfo
@@ -6,4 +6,4 @@
 6 5 0:5 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:6 - cgroup cgroup rw,cpuset
 7 5 0:6 /docker /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:7 - cgroup cgroup rw,cpu,cpuacct
 8 5 0:7 /docker /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory
-8 5 0:7 /docker/memory.vmstat /sys/fs/cgroup/vmstat rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory
+9 5 0:8 /docker/memory.vmstat /sys/fs/cgroup/vmstat rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory

--- a/internal/cgroups/testdata/proc/cgroups/mountinfo
+++ b/internal/cgroups/testdata/proc/cgroups/mountinfo
@@ -6,3 +6,4 @@
 6 5 0:5 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:6 - cgroup cgroup rw,cpuset
 7 5 0:6 /docker /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:7 - cgroup cgroup rw,cpu,cpuacct
 8 5 0:7 /docker /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory
+8 5 0:7 /docker/memory.vmstat /sys/fs/cgroup/vmstat rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory


### PR DESCRIPTION
When use **make test** base on this case
`8 5 0:7 /docker /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory
9 5 0:8 /docker/memory.vmstat /sys/fs/cgroup/vmstat rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory
`
been failed.

Because it's match multiple target，cannot uniquely match