### PR TITLE
ci: Test with Go 1.16/1.17, lint on 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.15.x", "1.16.x"]
+        go: ["1.16.x", "1.17.x"]
         include:
-        - go: 1.16.x
+        - go: 1.17.x
           latest: true
 
     steps:
@@ -26,7 +26,7 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v2
-      
+
     - name: Load cached dependencies
       uses: actions/cache@v1
       with:

--- a/internal/cgroups/cgroup.go
+++ b/internal/cgroups/cgroup.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/cgroup_test.go
+++ b/internal/cgroups/cgroup_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/cgroups.go
+++ b/internal/cgroups/cgroups.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/cgroups_test.go
+++ b/internal/cgroups/cgroups_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/errors.go
+++ b/internal/cgroups/errors.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/mountpoint.go
+++ b/internal/cgroups/mountpoint.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/mountpoint_test.go
+++ b/internal/cgroups/mountpoint_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/subsys.go
+++ b/internal/cgroups/subsys.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/subsys_test.go
+++ b/internal/cgroups/subsys_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/cgroups/util_test.go
+++ b/internal/cgroups/util_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package cgroups

--- a/internal/runtime/cpu_quota_linux.go
+++ b/internal/runtime/cpu_quota_linux.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package runtime

--- a/internal/runtime/cpu_quota_unsupported.go
+++ b/internal/runtime/cpu_quota_unsupported.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build !linux
 // +build !linux
 
 package runtime

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
Run gofmt on everything to add `//go:build` tags.
