### PR TITLE
Prepare release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.0 (2022-04-05)
+
+- Add support for cgroups v2.
+
+Thanks to @emadolsky for their contribution to this release.
+
 ## v1.4.0 (2021-02-01)
 
 - Support colons in cgroup names.

--- a/maxprocs/version.go
+++ b/maxprocs/version.go
@@ -21,4 +21,4 @@
 package maxprocs
 
 // Version is the current package version.
-const Version = "1.4.0"
+const Version = "1.5.0"


### PR DESCRIPTION
Release v1.5.0 with support for cgroups2.

In addition to the tests, I've deployed this change to a staging machine
internally to verify that it doesn't break cgroups v1 for us.

Refs GO-1322
