### PR TITLE
README: add a benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ func main() {
 }
 ```
 
-# Benchmarks
+# Performance
 Data measured from Uber's internal load balancer. We ran the load balancer with 200% CPU quota (i.e., 2 cores):
 
 | GOMAXPROCS         |  RPS      | P50 (ms) | P99.9 (ms) |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@ func main() {
 }
 ```
 
+# Benchmarks
+Data measured from Uber's internal load balancer. We ran the load balancer with 200% CPU quota (i.e., 2 cores):
+
+| GOMAXPROCS         |  RPS      | P50 (ms) | P99.9 (ms) |
+| ------------------ | --------- | -------- | ---------- |
+| 1                  | 28,893.18 | 1.46     | 19.70      |
+| 2 (equal to quota) | 44,715.07 | 0.84     | 26.38      |
+| 3                  | 44,212.93 | 0.66     | 30.07      |
+| 4                  | 41,071.15 | 0.57     | 42.94      |
+| 8                  | 33,111.69 | 0.43     | 64.32      |
+| Default (24)       | 22,191.40 | 0.45     | 76.19      |
+
+When `GOMAXPROCS` is increased above the CPU quota, we see P50 decrease slightly, but see significant increases to P99. We also see that the total RPS handled also decreases.
+
+When `GOMAXPROCS` is higher than the CPU quota allocated, we also saw significant throttling:
+
+```
+$ cat /sys/fs/cgroup/cpu,cpuacct/system.slice/[...]/cpu.stat
+nr_periods 42227334
+nr_throttled 131923
+throttled_time 88613212216618
+```
+
+Once `GOMAXPROCS` was reduced to match the CPU quota, we saw no CPU throttling.
+
 ## Development Status: Stable
 
 All APIs are finalized, and no breaking changes will be made in the 1.x series


### PR DESCRIPTION
This diff adds a single benchmark from the: https://github.com/uber-go/automaxprocs/issues/12#issuecomment-569327824