### PR TITLE
defer close cpuMaxParams to fix leak

### DIFF
--- a/internal/cgroups/cgroups2.go
+++ b/internal/cgroups/cgroups2.go
@@ -133,6 +133,7 @@ func (cg *CGroups2) CPUQuota() (float64, bool, error) {
 		}
 		return -1, false, err
 	}
+	defer cpuMaxParams.Close()
 
 	scanner := bufio.NewScanner(cpuMaxParams)
 	if scanner.Scan() {


### PR DESCRIPTION
Fixes a leak with the file descriptor within the cgroups v2 functionality.