### PR TITLE
feature: set GOMAXPROCS env var during Set

### DIFF
--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -26,6 +26,7 @@ package maxprocs // import "go.uber.org/automaxprocs/maxprocs"
 import (
 	"os"
 	"runtime"
+	"strconv"
 
 	iruntime "go.uber.org/automaxprocs/internal/runtime"
 )
@@ -126,5 +127,7 @@ func Set(opts ...Option) (func(), error) {
 	}
 
 	runtime.GOMAXPROCS(maxProcs)
+
+	_ = os.Setenv("GOMAXPROCS", strconv.Itoa(maxProcs))
 	return undo, nil
 }

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -87,11 +87,16 @@ func TestSet(t *testing.T) {
 
 	t.Run("EnvVarPresent", func(t *testing.T) {
 		withMax(t, 42, func() {
+			assert.Equal(t, "", os.Getenv(_maxProcsKey), "shouldn't have GOMAXPROCS env var")
 			prev := currentMaxProcs()
 			undo, err := Set()
 			defer undo()
 			require.NoError(t, err, "Set failed")
-			assert.Equal(t, prev, currentMaxProcs(), "shouldn't alter GOMAXPROCS")
+
+			after := currentMaxProcs()
+			assert.Equal(t, prev, after, "shouldn't alter GOMAXPROCS")
+			assert.Equal(t, strconv.Itoa(after), os.Getenv(_maxProcsKey), "should have GOMAXPROCS env var")
+			_ = os.Unsetenv(_maxProcsKey)
 		})
 	})
 


### PR DESCRIPTION
Currently, when do `import _ "go.uber.org/automaxprocs"`, the `GOMAXPROCS` is set automatically for users. 
But it doesn't set up the `GOMAXPROCS` environment variable which means if the programs `exec` some children processes to do some work, the env var needs to be set up manually.

For me, I think there are no side effects to setup the `GOMAXPROCS` environment variable also when we set up it in the program. So I raised this PR.

Regrads.