### PR TITLE
Release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.2 (2023-03-16)
+
+- Support child control cgroups
+- Fix file descriptor leak
+- Update dependencies
+
 ## v1.5.1 (2022-04-06)
 
 - Fix cgroups v2 mountpoint detection.

--- a/maxprocs/version.go
+++ b/maxprocs/version.go
@@ -21,4 +21,4 @@
 package maxprocs
 
 // Version is the current package version.
-const Version = "1.5.1"
+const Version = "1.5.2"


### PR DESCRIPTION
Commits in this release:

* e1c1306 - (origin/master, origin/HEAD, master) Test against Go 1.20 (5 hours ago) <Albert Wang>
* 77a1338 - CI: upgrade staticcheck to v2023.1.2 to make test pass, Add go1.19 (2 weeks ago) <shvc>
* abb2d82 - Bump golang.org/x/sys in /tools (#60) (3 weeks ago) <dependabot[bot]>
* 58f5aee - typo fix in runtime.go (3 months ago) <yutaroyamanaka>
*   db7cbd0 - Merge pull request #57 from rphillips/fix_leak (3 months ago) <Sung Yoon Whang>
|\
| * 1759cfc - defer close cpuMaxParams to fix leak (7 months ago) <Ryan Phillips>
|/
* 0b356b1 - Upgrade to yaml.v3 3.0.1 (#55) (10 months ago) <Abhinav Gupta>
* d835ace - Support child control cgroups in cgroupsv2 (#53) (11 months ago) <Maciej Biłas>
* ce572da - README: add performance section (#52) (11 months ago) <Alexey Ivanov>