### PR TITLE
fix: mountinfo parsing

### DIFF
--- a/internal/cgroups/mountpoint.go
+++ b/internal/cgroups/mountpoint.go
@@ -95,8 +95,12 @@ func NewMountPointFromLine(line string) (*MountPoint, error) {
 
 	for i, field := range fields[_miFieldIDOptionalFields:] {
 		if field == _mountInfoOptionalFieldsSep {
+			// End of optional fields.
 			fsTypeStart := _miFieldIDOptionalFields + i + 1
 
+			// Now we know where the optional fields end, split the line again with a
+			// limit to avoid issues with spaces in super options as present on WSL.
+			fields = strings.SplitN(line, _mountInfoSep, fsTypeStart+_miFieldCountSecondHalf)
 			if len(fields) != fsTypeStart+_miFieldCountSecondHalf {
 				return nil, mountPointFormatInvalidError{line}
 			}

--- a/internal/cgroups/mountpoint_test.go
+++ b/internal/cgroups/mountpoint_test.go
@@ -67,12 +67,37 @@ func TestNewMountPointFromLine(t *testing.T) {
 				SuperOptions:   []string{"rw", "cpu"},
 			},
 		},
+		{
+			name: "wsl",
+			line: `560 77 0:138 / /Docker/host rw,noatime - 9p drvfs rw,dirsync,aname=drvfs;path=C:\Program Files\Docker\Docker\resources;symlinkroot=/mnt/,mmap,access=client,msize=262144,trans=virtio`,
+			expected: &MountPoint{
+				MountID:        560,
+				ParentID:       77,
+				DeviceID:       "0:138",
+				Root:           "/",
+				MountPoint:     "/Docker/host",
+				Options:        []string{"rw", "noatime"},
+				OptionalFields: []string{},
+				FSType:         "9p",
+				MountSource:    "drvfs",
+				SuperOptions: []string{
+					"rw",
+					"dirsync",
+					`aname=drvfs;path=C:\Program Files\Docker\Docker\resources;symlinkroot=/mnt/`,
+					"mmap",
+					"access=client",
+					"msize=262144",
+					"trans=virtio",
+				},
+			},
+		},
 	}
 
 	for _, tt := range testTable {
 		mountPoint, err := NewMountPointFromLine(tt.line)
-		assert.Equal(t, tt.expected, mountPoint, tt.name)
-		assert.NoError(t, err, tt.name)
+		if assert.NoError(t, err, tt.name) {
+			assert.Equal(t, tt.expected, mountPoint, tt.name)
+		}
 	}
 }
 


### PR DESCRIPTION
Fix the parsing of mountinfo when super options has fields with spaces in, which is the case on WSL as it includes `path=C:\\Program Files\...`.

Fixes #72