### PR TITLE
Release v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.3 (2023-07-19)
+
+- Fix mountinfo parsing when super options have fields with spaces.
+- Fix division by zero while parsing cgroups.
+
 ## v1.5.2 (2023-03-16)
 
 - Support child control cgroups


### PR DESCRIPTION
Bug fixes on top of v1.5.2. Fixes for division by zero and mountinfo parsing.