### PR TITLE
Add option to round up CPU quota

### DIFF
--- a/internal/runtime/cpu_quota_linux.go
+++ b/internal/runtime/cpu_quota_linux.go
@@ -32,7 +32,7 @@ import (
 
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value.
-func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
+func CPUQuotaToGOMAXPROCS(minValue int, roundUpQuota bool) (int, CPUQuotaStatus, error) {
 	cgroups, err := newQueryer()
 	if err != nil {
 		return -1, CPUQuotaUndefined, err
@@ -44,6 +44,9 @@ func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
 	}
 
 	maxProcs := int(math.Floor(quota))
+	if roundUpQuota {
+		maxProcs = int(math.Ceil(quota))
+	}
 	if minValue > 0 && maxProcs < minValue {
 		return minValue, CPUQuotaMinUsed, nil
 	}

--- a/internal/runtime/cpu_quota_linux.go
+++ b/internal/runtime/cpu_quota_linux.go
@@ -25,16 +25,18 @@ package runtime
 
 import (
 	"errors"
-	"math"
 
 	cg "go.uber.org/automaxprocs/internal/cgroups"
 )
 
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
-// to a valid GOMAXPROCS value. The quota is rounded to an int using roundOpt.
-// The default is rounding down (Floor).
-func CPUQuotaToGOMAXPROCS(minValue int, roundOpt Rounding) (int, CPUQuotaStatus, error) {
-	cgroups, err := newQueryer()
+// to a valid GOMAXPROCS value. The quota is converted from float to int using round.
+// If round == nil, DefaultRoundFunc is used.
+func CPUQuotaToGOMAXPROCS(minValue int, round func(v float64) int) (int, CPUQuotaStatus, error) {
+	if round == nil {
+		round = DefaultRoundFunc
+	}
+	cgroups, err := _newQueryer()
 	if err != nil {
 		return -1, CPUQuotaUndefined, err
 	}
@@ -44,10 +46,7 @@ func CPUQuotaToGOMAXPROCS(minValue int, roundOpt Rounding) (int, CPUQuotaStatus,
 		return -1, CPUQuotaUndefined, err
 	}
 
-	maxProcs := int(math.Floor(quota))
-	if roundOpt == Ceil {
-		maxProcs = int(math.Ceil(quota))
-	}
+	maxProcs := round(quota)
 	if minValue > 0 && maxProcs < minValue {
 		return minValue, CPUQuotaMinUsed, nil
 	}
@@ -61,6 +60,7 @@ type queryer interface {
 var (
 	_newCgroups2 = cg.NewCGroups2ForCurrentProcess
 	_newCgroups  = cg.NewCGroupsForCurrentProcess
+	_newQueryer  = newQueryer
 )
 
 func newQueryer() (queryer, error) {

--- a/internal/runtime/cpu_quota_linux.go
+++ b/internal/runtime/cpu_quota_linux.go
@@ -31,8 +31,9 @@ import (
 )
 
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
-// to a valid GOMAXPROCS value.
-func CPUQuotaToGOMAXPROCS(minValue int, roundUpQuota bool) (int, CPUQuotaStatus, error) {
+// to a valid GOMAXPROCS value. The quota is rounded to an int using roundOpt.
+// The default is rounding down (Floor).
+func CPUQuotaToGOMAXPROCS(minValue int, roundOpt Rounding) (int, CPUQuotaStatus, error) {
 	cgroups, err := newQueryer()
 	if err != nil {
 		return -1, CPUQuotaUndefined, err
@@ -44,7 +45,7 @@ func CPUQuotaToGOMAXPROCS(minValue int, roundUpQuota bool) (int, CPUQuotaStatus,
 	}
 
 	maxProcs := int(math.Floor(quota))
-	if roundUpQuota {
+	if roundOpt == Ceil {
 		maxProcs = int(math.Ceil(quota))
 	}
 	if minValue > 0 && maxProcs < minValue {

--- a/internal/runtime/cpu_quota_linux_test.go
+++ b/internal/runtime/cpu_quota_linux_test.go
@@ -26,6 +26,7 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/prashantv/gostub"
@@ -86,22 +87,22 @@ func TestNewQueryer(t *testing.T) {
 		stubs := newStubs(t)
 
 		q := testQueryer{v: 2.7}
-		stubs.StubFunc(&_newCgroups2, q, nil)
+		stubs.StubFunc(&_newQueryer, q, nil)
 
-		got, _, err := CPUQuotaToGOMAXPROCS(0, Ceil)
+		got, _, err := CPUQuotaToGOMAXPROCS(0, func(v float64) int { return int(math.Ceil(v)) })
 		require.NoError(t, err)
-		assert.Same(t, 3, got)
+		assert.Equal(t, 3, got)
 	})
 
 	t.Run("round quota with floor", func(t *testing.T) {
 		stubs := newStubs(t)
 
 		q := testQueryer{v: 2.7}
-		stubs.StubFunc(&_newCgroups2, q, nil)
+		stubs.StubFunc(&_newQueryer, q, nil)
 
-		got, _, err := CPUQuotaToGOMAXPROCS(0, Floor)
+		got, _, err := CPUQuotaToGOMAXPROCS(0, func(v float64) int { return int(math.Floor(v)) })
 		require.NoError(t, err)
-		assert.Same(t, 2, got)
+		assert.Equal(t, 2, got)
 	})
 }
 

--- a/internal/runtime/cpu_quota_linux_test.go
+++ b/internal/runtime/cpu_quota_linux_test.go
@@ -83,6 +83,18 @@ func TestNewQueryer(t *testing.T) {
 		assert.ErrorIs(t, err, giveErr)
 	})
 
+	t.Run("round quota with a nil round function", func(t *testing.T) {
+		stubs := newStubs(t)
+
+		q := testQueryer{v: 2.7}
+		stubs.StubFunc(&_newQueryer, q, nil)
+
+		// If round function is nil, CPUQuotaToGOMAXPROCS uses DefaultRoundFunc, which rounds down the value
+		got, _, err := CPUQuotaToGOMAXPROCS(0, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 2, got)
+	})
+
 	t.Run("round quota with ceil", func(t *testing.T) {
 		stubs := newStubs(t)
 

--- a/internal/runtime/cpu_quota_linux_test.go
+++ b/internal/runtime/cpu_quota_linux_test.go
@@ -81,6 +81,36 @@ func TestNewQueryer(t *testing.T) {
 		_, err := newQueryer()
 		assert.ErrorIs(t, err, giveErr)
 	})
+
+	t.Run("round quota with ceil", func(t *testing.T) {
+		stubs := newStubs(t)
+
+		q := testQueryer{v: 2.7}
+		stubs.StubFunc(&_newCgroups2, q, nil)
+
+		got, _, err := CPUQuotaToGOMAXPROCS(0, Ceil)
+		require.NoError(t, err)
+		assert.Same(t, 3, got)
+	})
+
+	t.Run("round quota with floor", func(t *testing.T) {
+		stubs := newStubs(t)
+
+		q := testQueryer{v: 2.7}
+		stubs.StubFunc(&_newCgroups2, q, nil)
+
+		got, _, err := CPUQuotaToGOMAXPROCS(0, Floor)
+		require.NoError(t, err)
+		assert.Same(t, 2, got)
+	})
+}
+
+type testQueryer struct {
+	v float64
+}
+
+func (tq testQueryer) CPUQuota() (float64, bool, error) {
+	return tq.v, true, nil
 }
 
 func newStubs(t *testing.T) *gostub.Stubs {

--- a/internal/runtime/cpu_quota_unsupported.go
+++ b/internal/runtime/cpu_quota_unsupported.go
@@ -26,6 +26,6 @@ package runtime
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value. This is Linux-specific and not supported in the
 // current OS.
-func CPUQuotaToGOMAXPROCS(_ int, _ Rounding) (int, CPUQuotaStatus, error) {
+func CPUQuotaToGOMAXPROCS(_ int, _ func(v float64) int) (int, CPUQuotaStatus, error) {
 	return -1, CPUQuotaUndefined, nil
 }

--- a/internal/runtime/cpu_quota_unsupported.go
+++ b/internal/runtime/cpu_quota_unsupported.go
@@ -26,6 +26,6 @@ package runtime
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value. This is Linux-specific and not supported in the
 // current OS.
-func CPUQuotaToGOMAXPROCS(_ int, _ bool) (int, CPUQuotaStatus, error) {
+func CPUQuotaToGOMAXPROCS(_ int, _ Rounding) (int, CPUQuotaStatus, error) {
 	return -1, CPUQuotaUndefined, nil
 }

--- a/internal/runtime/cpu_quota_unsupported.go
+++ b/internal/runtime/cpu_quota_unsupported.go
@@ -26,6 +26,6 @@ package runtime
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value. This is Linux-specific and not supported in the
 // current OS.
-func CPUQuotaToGOMAXPROCS(_ int) (int, CPUQuotaStatus, error) {
+func CPUQuotaToGOMAXPROCS(_ int, _ bool) (int, CPUQuotaStatus, error) {
 	return -1, CPUQuotaUndefined, nil
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -20,6 +20,8 @@
 
 package runtime
 
+import "math"
+
 // CPUQuotaStatus presents the status of how CPU quota is used
 type CPUQuotaStatus int
 
@@ -32,12 +34,7 @@ const (
 	CPUQuotaMinUsed
 )
 
-// Rounding controls how the CPU quota value should be rounded to an int
-type Rounding int
-
-const (
-	// Ceil is used to return a CPU quota rounded up
-	Ceil Rounding = iota
-	// Floor is used to return a CPU quota rounded down
-	Floor
-)
+// DefaultRoundFunc is the default function to convert CPU quota from float to int. It rounds the value down (floor).
+func DefaultRoundFunc(v float64) int {
+	return int(math.Floor(v))
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -31,3 +31,13 @@ const (
 	// CPUQuotaMinUsed is returned when CPU quota is smaller than the min value
 	CPUQuotaMinUsed
 )
+
+// Rounding controls how the CPU quota value should be rounded to an int
+type Rounding int
+
+const (
+	// Ceil is used to return a CPU quota rounded up
+	Ceil Rounding = iota
+	// Floor is used to return a CPU quota rounded down
+	Floor
+)

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -92,6 +92,7 @@ func Set(opts ...Option) (func(), error) {
 	cfg := &config{
 		procs:         iruntime.CPUQuotaToGOMAXPROCS,
 		minGOMAXPROCS: 1,
+		roundQuota:    iruntime.Floor,
 	}
 	for _, o := range opts {
 		o.apply(cfg)

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -38,9 +38,9 @@ func currentMaxProcs() int {
 
 type config struct {
 	printf        func(string, ...interface{})
-	procs         func(int, bool) (int, iruntime.CPUQuotaStatus, error)
+	procs         func(int, iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error)
 	minGOMAXPROCS int
-	roundUpQuota  bool
+	roundQuota    iruntime.Rounding
 }
 
 func (c *config) log(fmt string, args ...interface{}) {
@@ -72,10 +72,10 @@ func Min(n int) Option {
 	})
 }
 
-// RoundUpQuota controls whether the CPU quota should be rounded up instead of down.
-func RoundUpQuota(v bool) Option {
+// RoundQuota controls whether the CPU quota should be rounded using ceil or floor.
+func RoundQuota(v iruntime.Rounding) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.roundUpQuota = v
+		cfg.roundQuota = v
 	})
 }
 
@@ -110,7 +110,7 @@ func Set(opts ...Option) (func(), error) {
 		return undoNoop, nil
 	}
 
-	maxProcs, status, err := cfg.procs(cfg.minGOMAXPROCS, cfg.roundUpQuota)
+	maxProcs, status, err := cfg.procs(cfg.minGOMAXPROCS, cfg.roundQuota)
 	if err != nil {
 		return undoNoop, err
 	}

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -55,7 +55,7 @@ func testLogger() (*bytes.Buffer, Option) {
 	return buf, Logger(printf)
 }
 
-func stubProcs(f func(int, bool) (int, iruntime.CPUQuotaStatus, error)) Option {
+func stubProcs(f func(int, iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error)) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.procs = f
 	})
@@ -96,7 +96,7 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("ErrorReadingQuota", func(t *testing.T) {
-		opt := stubProcs(func(int, bool) (int, iruntime.CPUQuotaStatus, error) {
+		opt := stubProcs(func(int, iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
 			return 0, iruntime.CPUQuotaUndefined, errors.New("failed")
 		})
 		prev := currentMaxProcs()
@@ -109,7 +109,7 @@ func TestSet(t *testing.T) {
 
 	t.Run("QuotaUndefined", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubProcs(func(int, bool) (int, iruntime.CPUQuotaStatus, error) {
+		quotaOpt := stubProcs(func(int, iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
 			return 0, iruntime.CPUQuotaUndefined, nil
 		})
 		prev := currentMaxProcs()
@@ -122,7 +122,7 @@ func TestSet(t *testing.T) {
 
 	t.Run("QuotaUndefined return maxProcs=7", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubProcs(func(int, bool) (int, iruntime.CPUQuotaStatus, error) {
+		quotaOpt := stubProcs(func(int, iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
 			return 7, iruntime.CPUQuotaUndefined, nil
 		})
 		prev := currentMaxProcs()
@@ -135,7 +135,7 @@ func TestSet(t *testing.T) {
 
 	t.Run("QuotaTooSmall", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubProcs(func(min int, roundUpQuota bool) (int, iruntime.CPUQuotaStatus, error) {
+		quotaOpt := stubProcs(func(min int, round iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
 			return min, iruntime.CPUQuotaMinUsed, nil
 		})
 		undo, err := Set(logOpt, quotaOpt, Min(5))
@@ -147,7 +147,7 @@ func TestSet(t *testing.T) {
 
 	t.Run("Min unused", func(t *testing.T) {
 		buf, logOpt := testLogger()
-		quotaOpt := stubProcs(func(min int, roundUpQuota bool) (int, iruntime.CPUQuotaStatus, error) {
+		quotaOpt := stubProcs(func(min int, round iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
 			return min, iruntime.CPUQuotaMinUsed, nil
 		})
 		// Min(-1) should be ignored.
@@ -159,7 +159,7 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("QuotaUsed", func(t *testing.T) {
-		opt := stubProcs(func(min int, roundUpQuota bool) (int, iruntime.CPUQuotaStatus, error) {
+		opt := stubProcs(func(min int, round iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
 			assert.Equal(t, 1, min, "Default minimum value should be 1")
 			return 42, iruntime.CPUQuotaUsed, nil
 		})
@@ -169,23 +169,23 @@ func TestSet(t *testing.T) {
 		assert.Equal(t, 42, currentMaxProcs(), "should change GOMAXPROCS to match quota")
 	})
 
-	t.Run("RoundUpQuotaSetToTrue", func(t *testing.T) {
-		opt := stubProcs(func(min int, roundUpQuota bool) (int, iruntime.CPUQuotaStatus, error) {
-			assert.Equal(t, true, roundUpQuota, "roundUpQuota should be true")
+	t.Run("RoundQuotaSetToCeil", func(t *testing.T) {
+		opt := stubProcs(func(min int, round iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
+			assert.Equal(t, iruntime.Ceil, round, "round should be Ceil")
 			return 43, iruntime.CPUQuotaUsed, nil
 		})
-		undo, err := Set(opt, RoundUpQuota(true))
+		undo, err := Set(opt, RoundQuota(iruntime.Ceil))
 		defer undo()
 		require.NoError(t, err, "Set failed")
 		assert.Equal(t, 43, currentMaxProcs(), "should change GOMAXPROCS to match rounded up quota")
 	})
 
-	t.Run("RoundUpQuotaSetToFalse", func(t *testing.T) {
-		opt := stubProcs(func(min int, roundUpQuota bool) (int, iruntime.CPUQuotaStatus, error) {
-			assert.Equal(t, false, roundUpQuota, "roundUpQuota should be false")
+	t.Run("RoundQuotaSetToFloor", func(t *testing.T) {
+		opt := stubProcs(func(min int, round iruntime.Rounding) (int, iruntime.CPUQuotaStatus, error) {
+			assert.Equal(t, iruntime.Floor, round, "round should be Floor")
 			return 42, iruntime.CPUQuotaUsed, nil
 		})
-		undo, err := Set(opt, RoundUpQuota(false))
+		undo, err := Set(opt, RoundQuota(iruntime.Floor))
 		defer undo()
 		require.NoError(t, err, "Set failed")
 		assert.Equal(t, 42, currentMaxProcs(), "should change GOMAXPROCS to match rounded up quota")


### PR DESCRIPTION
Add a `RoundQuotaFunc` option to control how the CPU quota should be rounded. The default is still rounding down (floor).
This is related to issue https://github.com/uber-go/automaxprocs/issues/78