### PR TITLE
Use Go 1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19.x", "1.20.x"]
+        go: ["1.20.x", "1.21.x"]
         include:
-        - go: 1.20.x
+        - go: 1.21.x
           latest: true
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/automaxprocs
 
-go 1.18
+go 1.20
 
 require (
 	github.com/prashantv/gostub v1.1.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/automaxprocs/tools
 
-go 1.18
+go 1.20
 
 require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616


### PR DESCRIPTION
This updates go.mod files to use Go 1.21.

It also updates the CI to use Go 1.20 and Go 1.21 to test.

Note that this specifies the minimum version required to work with automaxprocs to be Go 1.20 as specified in the toolchain specification (https://go.dev/doc/toolchain).
