### PR TITLE
Remove glide.yaml

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,0 @@
-package: go.uber.org/automaxprocs
-import: []
-testImport:
-- package: github.com/stretchr/testify
-  version: ^1.1.4
-  subpackages:
-  - assert


### PR DESCRIPTION
We've longed moved away to go.mod and install using glide is no longer
supported. Remove glide.yaml file to clean up unused files.
