### PR TITLE
test the CI in 1.22 and 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20.x", "1.21.x"]
+        go: ["1.22.x", "1.23.x"]
         include:
-        - go: 1.21.x
+        - go: 1.23.x
           latest: true
 
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
And drop the older Go versions in test matrix.